### PR TITLE
fix: upgrade Next.js to 15.4.10 to patch CVE-2025-55184 and CVE-2025-55183

### DIFF
--- a/datasheetsChat/package-lock.json
+++ b/datasheetsChat/package-lock.json
@@ -18,7 +18,7 @@
         "@vectorize-io/vectorize-client": "^0.2.1",
         "ai": "^5.0.68",
         "lucide-react": "^0.468.0",
-        "next": "^15.4.8",
+        "next": "^15.4.10",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^9.0.1",
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.8.tgz",
-      "integrity": "sha512-LydLa2MDI1NMrOFSkO54mTc8iIHSttj6R6dthITky9ylXV2gCGi0bHQjVCtLGRshdRPjyh2kXbxJukDtBWQZtQ==",
+      "version": "15.4.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.10.tgz",
+      "integrity": "sha512-knhmoJ0Vv7VRf6pZEPSnciUG1S4bIhWx+qTYBW/AjxEtlzsiNORPk8sFDCEvqLfmKuey56UB9FL1UdHEV3uBrg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -5128,12 +5128,12 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.8.tgz",
-      "integrity": "sha512-jwOXTz/bo0Pvlf20FSb6VXVeWRssA2vbvq9SdrOPEg9x8E1B27C2rQtvriAn600o9hH61kjrVRexEffv3JybuA==",
+      "version": "15.4.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.4.10.tgz",
+      "integrity": "sha512-itVlc79QjpKMFMRhP+kbGKaSG/gZM6RCvwhEbwmCNF06CdDiNaoHcbeg0PqkEa2GOcn8KJ0nnc7+yL7EjoYLHQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.8",
+        "@next/env": "15.4.10",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/datasheetsChat/package.json
+++ b/datasheetsChat/package.json
@@ -19,7 +19,7 @@
     "@vectorize-io/vectorize-client": "^0.2.1",
     "ai": "^5.0.68",
     "lucide-react": "^0.468.0",
-    "next": "^15.4.8",
+    "next": "^15.4.10",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.1",


### PR DESCRIPTION
## Summary
- Upgrades Next.js to 15.4.10 to patch CVE-2025-55184 and CVE-2025-55183

## Security Impact
- **CVE-2025-55184** (High) - Denial of Service via malicious HTTP request to App Router endpoints
- **CVE-2025-55183** (Medium) - Source Code Exposure of Server Actions

## Reference
https://github.com/vercel/next.js/security/advisories